### PR TITLE
Log error if `mamp add` is invoked without a `<shortcut>` argument.

### DIFF
--- a/lib/commands/CommandAdd.coffee
+++ b/lib/commands/CommandAdd.coffee
@@ -4,5 +4,11 @@ module.exports = class CommandAdd
   constructor: (argv) ->
     targetDir = process.cwd()
     shortcut = argv["_"][1]
-    config = new Config
-    config.add shortcut, targetDir
+
+    if shortcut
+      config = new Config
+      config.add shortcut, targetDir
+    else
+      console.error "Error: Missing argument <shortcut>\r"
+      console.error "Please ensure that your use of the 'add' command looks like this:\r"
+      console.error "mamp add <shortcut>"

--- a/readme.md
+++ b/readme.md
@@ -58,6 +58,10 @@ Use this to print the help:
 
 ### Version History
 
+#### Unreleased
+
+- updated `mamp add` command to log error if `<shortcut>` argument is missing.
+
 ##### 0.0.8
 
 - added the possibility to pass a path to `mamp switch`


### PR DESCRIPTION
## Description
If the `mamp add` command is invoked without a `<shortcut>` argument, an error message/additional usage instructions will be displayed.

## Motivation and Context
Currently, invoking `mamp add` adds the following key/value pair to the `.mamp-cli` file:

```
"undefined": "/path/to/file"
```

This update prevents `undefined` shortcuts from being added to the `.mamp-cli` file by ensuring that the `<shortcut>` argument is always present.

## How Has This Been Tested?
This update has been tested on my local, forked version of the `mamp-cli` package.

## Screenshots (if appropriate):

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.

P.S.
First of all, thanks for putting together such a great tool. `mamp-cli` definitely beats having to make manual updates to the `MAMP.app` config files.